### PR TITLE
Make GPIO Chip configurable, fix custom device definition

### DIFF
--- a/app/linux/src/LightingManager.cpp
+++ b/app/linux/src/LightingManager.cpp
@@ -37,7 +37,7 @@ LightingManager LightingManager::sLight;
 #define GPIO "GPIO"
 #define GPIOCHIP "GPIOCHIP"
 
-#define GPIO_CONSUMER "Lighting_Manager"
+#define GPIO_CONSUMER "matter-commander"
 
 static int gpio;
 static struct gpiod_line *gpioLine;

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,3 +7,9 @@ if [[ -n $GPIO ]] && ! [[ $GPIO =~ ^[1-9][0-9]*$ ]]; then
     logger -t $TAG --stderr "gpio: '$GPIO' is not a positive integer"
     exit 1
 fi
+
+GPIOCHIP=$(snapctl get gpiochip)
+if (( GPIOCHIP != 0 && GPIOCHIP != 4 )); then
+    logger -t $TAG --stderr "gpiochip: '$GPIOCHIP' is not supported; set to 0 or 4"
+    exit 1
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Set defaults
+snapctl set gpiochip=0

--- a/snap/local/bin/load-snap-options.sh
+++ b/snap/local/bin/load-snap-options.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 export GPIO=$(snapctl get gpio)
+export GPIOCHIP=$(snapctl get gpiochip)
 export ARGS=$(snapctl get args)
 
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,10 +18,14 @@ slots:
     interface: custom-device
     custom-device: gpiochip
     devices:
-      - /dev/gpiochip[0-4]
+      # Legacy Raspberry Pis
+      - /dev/gpiochip0
+      # Raspberry Pi 5
+      - /dev/gpiochip4
     files:
       read:
-        - /sys/devices/platform/soc/*.gpio/gpiochip[0-4]/dev
+        - /sys/devices/platform/soc/*.gpio/gpiochip0/dev
+        - /sys/devices/platform/axi/*.pcie/*.gpio/gpiochip4/dev
 
 plugs:
   # This is to communicate with the OpenThread Border Router snap (https://snapcraft.io/openthread-border-router)

--- a/test-blink.cpp
+++ b/test-blink.cpp
@@ -11,7 +11,7 @@
 #define GPIO "GPIO"
 #define GPIOCHIP "GPIOCHIP"
 
-#define GPIO_CONSUMER "test-blink"
+#define GPIO_CONSUMER "matter-commander-test-blink"
 
 void setGpioLineValue(struct gpiod_line *line, int value);
 

--- a/test-blink.cpp
+++ b/test-blink.cpp
@@ -7,9 +7,12 @@
 #include <cstring>
 #include <unistd.h>
 
+// Environment variables
 #define GPIO "GPIO"
+#define GPIOCHIP "GPIOCHIP"
+
 #define CONSUMER "test-blink"
-#define GPIO_CHIP "/dev/gpiochip0"
+// #define GPIO_CHIP "/dev/gpiochip4"
 
 void setGpioLineValue(struct gpiod_line *line, int value);
 
@@ -17,18 +20,28 @@ int main(void)
 {
     struct gpiod_line *line;
 
+    // Read environment variables
     char *envGPIO = std::getenv(GPIO);
     if (envGPIO == NULL || strlen(envGPIO) == 0)
     {
-        std::cout << "Environment variable not set or empty: " << GPIO << std::endl;
+        std::cout << "Unset or empty environment variable: " << GPIO << std::endl;
         return 1;
     }
+    std::cout << "GPIO: " << envGPIO << std::endl;
 
+    char *envGPIOCHIP = std::getenv(GPIOCHIP);
+    if (envGPIOCHIP == NULL || strlen(envGPIOCHIP) == 0)
+    {
+        std::cout << "Unset or empty environment variable: " << GPIOCHIP << std::endl;
+        return 1;
+    }
+    std::cout << "GPIOCHIP: " << envGPIOCHIP << std::endl;
+
+    // Convert
     int gpio;
     try
     {
         gpio = std::stoi(envGPIO);
-        std::cout << "GPIO: " << gpio << std::endl;
     }
     catch (std::exception &ex)
     {
@@ -36,13 +49,15 @@ int main(void)
         return 1;
     }
 
+    std::string gpioDevice = (std::string)"/dev/gpiochip" + envGPIOCHIP;
+    
     // Setup GPIO with libgpiod
     struct gpiod_chip *chip;
 
-    chip = gpiod_chip_open(GPIO_CHIP);
+    chip = gpiod_chip_open(gpioDevice.c_str());
     if (!chip)
     {
-        std::cerr << "Failed to open gpio chip: " << GPIO_CHIP << std::endl;
+        std::cerr << "Failed to open gpio chip: " << gpioDevice << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
This PR is made against https://github.com/canonical/matter-pi-gpio-commander/pull/42. It makes the gpiochip configurable and refactors the custom-device snap interface to give fine-grained access to the devices and corresponding system files. There are also some minor improvements in the logging.

Note that the code can now benefit from some refactoring for the environment variable loading. 

Testing instructions are similar to [here](https://github.com/canonical/matter-pi-gpio-commander/pull/42#pullrequestreview-1848292073), with the addition of `gpiochip` configuration:

The default is set to 0. For RPi5, it needs to be changed to 4:
```
$ sudo snap get matter-pi-gpio-commander 
Key       Value
gpiochip  0

$ sudo snap set matter-pi-gpio-commander gpiochip=4
```

By design, any value other than 0 and 4 results in error:
```
$ sudo snap set matter-pi-gpio-commander gpiochip=2
error: cannot perform the following tasks:
- Run configure hook of "matter-pi-gpio-commander" snap (run hook "configure": <13>Feb  5 13:43:38 matter-pi-gpio-commander.configure: gpiochip: '2' is not supported; set to 0 or 4)
```
This is because the custom-device interface only allows access to those.